### PR TITLE
Add permissions to Github workflow

### DIFF
--- a/.github/workflows/build_image.yml
+++ b/.github/workflows/build_image.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - master
 
+permissions:
+  packages: write
+  contents: read
+
 jobs:
   build-container:
     uses: fsinfuhh/workflows/.github/workflows/build_image.yml@main


### PR DESCRIPTION
I think the workflow is failing because it is missing package write permissions.