### PR TITLE
Fix VITE_HOSTNAME environment variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ FROM node:18 AS frontend
 # Build frontend
 ADD frontend /app/frontend
 WORKDIR /app/frontend
-ENV VITE_HOSTNAME=/api/
+ENV VITE_HOSTNAME=karaoke.mafiasi.de/api/
 RUN npm install
 RUN npm run build
 


### PR DESCRIPTION
Currently, we get the error `TypeError: URL constructor: /api/ is not a valid URL.`. I assume that the hostname has to be added.